### PR TITLE
Updates sablier subgraph uri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .history
+.vscode

--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -4,6 +4,6 @@ import {
 } from "@apollo/client";
 
 export const client = new ApolloClient({
-    uri: 'https://api.thegraph.com/subgraphs/name/sablierhq/sablier',
+    uri: 'https://api.thegraph.com/subgraphs/name/sablier-labs/sablier',
     cache: new InMemoryCache()
 });


### PR DESCRIPTION
Sablier subgraph changed from sablierhq to sablier-labs.

The old uri no longer works. This updates to the latest uri found here: https://thegraph.com/hosted-service/subgraph/sablier-labs/sablier

Sablier labs does seem to be the legit rebranding of sablierhq. https://twitter.com/Sablier/status/1660556396503482372?s=20